### PR TITLE
Point out dash background in comments

### DIFF
--- a/src/main/gnome-shell/shell-3-28/gnome-shell-dark.css
+++ b/src/main/gnome-shell/shell-3-28/gnome-shell-dark.css
@@ -3081,7 +3081,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 #dash {
   color: rgba(255, 255, 255, 0.7);
-  background-color: rgba(255, 255, 255, 0.12);
+  background-color: rgba(255, 255, 255, 0.12); /* dark dash background color */
   border-left: 0;
   border-radius: 0 12px 12px 0;
   padding: 6px;

--- a/src/main/gnome-shell/shell-3-28/gnome-shell-light.css
+++ b/src/main/gnome-shell/shell-3-28/gnome-shell-light.css
@@ -3081,7 +3081,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 #dash {
   color: rgba(255, 255, 255, 0.7);
-  background-color: rgba(255, 255, 255, 0.12);
+  background-color: rgba(255, 255, 255, 0.12);/* light dash background color */
   border-left: 0;
   border-radius: 0 12px 12px 0;
   padding: 6px;

--- a/src/main/gnome-shell/shell-3-28/gnome-shell.css
+++ b/src/main/gnome-shell/shell-3-28/gnome-shell.css
@@ -3081,7 +3081,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 #dash {
   color: rgba(255, 255, 255, 0.7);
-  background-color: rgba(255, 255, 255, 0.12);
+  background-color: rgba(255, 255, 255, 0.12); /* dash background color */
   border-left: 0;
   border-radius: 0 12px 12px 0;
   padding: 6px;

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-dark.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-dark.css
@@ -3008,7 +3008,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .dash-background {
-  background-color: rgba(255, 255, 255, 0.3);
+  background-color: rgba(255, 255, 255, 0.3); /* dark dash background color */
   margin-bottom: 16px;
   padding: 10px;
   border-radius: 16px;

--- a/src/main/gnome-shell/shell-40-0/gnome-shell-light.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell-light.css
@@ -3008,7 +3008,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .dash-background {
-  background-color: rgba(0, 0, 0, 0.26);
+  background-color: rgba(0, 0, 0, 0.26); /* light dash background color */
   margin-bottom: 16px;
   padding: 10px;
   border-radius: 16px;

--- a/src/main/gnome-shell/shell-40-0/gnome-shell.css
+++ b/src/main/gnome-shell/shell-40-0/gnome-shell.css
@@ -3008,7 +3008,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .dash-background {
-  background-color: rgba(255, 255, 255, 0.3);
+  background-color: rgba(255, 255, 255, 0.3); /* dash background color */
   margin-bottom: 16px;
   padding: 10px;
   border-radius: 16px;


### PR DESCRIPTION
The dash color is strange right now. This is the dark dash in gnome 40:
![Screenshot from 2022-01-05 23-23-25](https://user-images.githubusercontent.com/39594914/148265209-64e36209-2727-4296-a2df-78ac5753649d.png)
This is the light dash in gnome 40:
![Screenshot from 2022-01-05 23-22-53](https://user-images.githubusercontent.com/39594914/148265147-a6377fa5-ac9c-4815-9a93-ac1baebfd36b.png)

The problem is that the users of dark mode probably do not want a light dash, and light mode users probably dont want a black dash. If there is agreement in this, then we can change the color to something better and more suited to the theme..

the lead designer is better than me at figuring out the correct color to be used.. In this pull request I just want to point out the unusual css, hope it can be improved.