### PR TITLE
Fix a bug in copying some distro logos

### DIFF
--- a/other/grub2/assets/render-all.sh
+++ b/other/grub2/assets/render-all.sh
@@ -5,7 +5,7 @@ RESOLUTIONS=("1080p" "2k" "4k")
 
 for theme in "${THEMES[@]}"; do
   for resolution in "${RESOLUTIONS[@]}"; do
-    echo "./render-assets.sh \"$theme\" \"$resolution\": "
+    echo "./render-core.sh \"$theme\" \"$resolution\": "
     ./render-core.sh "$theme" "$resolution"
   done
 done

--- a/other/grub2/assets/render-core.sh
+++ b/other/grub2/assets/render-core.sh
@@ -42,7 +42,7 @@ while read -r i; do
   fi
 done < "$INDEX"
 
-if [[ "$EXPORT_TYPE" == "icons" ]]; then
+if [[ "$1" == "logos" ]]; then
   cd "$ASSETS_DIR" || exit 1
   cp -a archlinux.png arch.png
   cp -a gnu-linux.png linux.png


### PR DESCRIPTION
The last lines of `render-core.sh` was never executed. This small PR fixes the issue.