### PR TITLE
fixing quick menu issue

### DIFF
--- a/src/sass/gnome-shell/common/_buttons.scss
+++ b/src/sass/gnome-shell/common/_buttons.scss
@@ -26,3 +26,16 @@
     @extend %flat_button;
   }
 }
+
+.icon-button {
+    @extend .button; // same style as buttons
+
+    border-radius: 99px;
+    padding: $base_padding*2;
+    min-height: 16px;
+
+    StIcon {
+        icon-size: $base_icon_size;
+        -st-icon-style: symbolic;
+    }
+}

--- a/src/sass/gnome-shell/common/_quick-settings.scss
+++ b/src/sass/gnome-shell/common/_quick-settings.scss
@@ -160,15 +160,6 @@
 .quick-settings-system-item {
   & > StBoxLayout { spacing: 2 * $base_padding; }
 
-  .icon-button {
-    background-color: $button;
-    color: $text;
-    border-radius: $base_radius;
-    @extend %button;
-
-    > StIcon { -st-icon-style: symbolic; }
-  }
-
   & .power-item {
     min-height: 0;
     min-width: 0;


### PR DESCRIPTION
When using this as a GDM theme by compiling it and placing it in `/usr/share/gnome-shell/gnome-shell-theme.gresource` there is an issue with how icon buttons look in the quick menu.    
I found this recent PR in the gnome-shell repo and copied a minor change from it to fix the issue     
https://gitlab.gnome.org/GNOME/gnome-shell/-/commit/ea7b29e049d1478c301dbecec5d49cae8e528d7e