### PR TITLE
Adds light/dark wallpapers

### DIFF
--- a/wallpaper/Graphite-nord/Arch-Nord.xml
+++ b/wallpaper/Graphite-nord/Arch-Nord.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>Wave Arch Nord</name>
+    <filename>@BACKGROUNDDIR@/wave-Light-nord-arch.png</filename>
+    <filename-dark>@BACKGROUNDDIR@/wave-Dark-nord-arch.png</filename-dark>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#3071AE</pcolor>
+    <scolor>#000000</scolor>
+  </wallpaper>
+</wallpapers>
+

--- a/wallpaper/Graphite-nord/Arch-Nord.xml
+++ b/wallpaper/Graphite-nord/Arch-Nord.xml
@@ -6,9 +6,6 @@
     <filename>@BACKGROUNDDIR@/wave-Light-nord-arch.png</filename>
     <filename-dark>@BACKGROUNDDIR@/wave-Dark-nord-arch.png</filename-dark>
     <options>zoom</options>
-    <shade_type>solid</shade_type>
-    <pcolor>#3071AE</pcolor>
-    <scolor>#000000</scolor>
   </wallpaper>
 </wallpapers>
 

--- a/wallpaper/Graphite-nord/Debian-Nord.xml
+++ b/wallpaper/Graphite-nord/Debian-Nord.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>Wave Debian Nord</name>
+    <filename>@BACKGROUNDDIR@/wave-Light-nord-debian.png</filename>
+    <filename-dark>@BACKGROUNDDIR@/wave-Dark-nord-debian.png</filename-dark>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#3071AE</pcolor>
+    <scolor>#000000</scolor>
+  </wallpaper>
+</wallpapers>
+

--- a/wallpaper/Graphite-nord/Debian-Nord.xml
+++ b/wallpaper/Graphite-nord/Debian-Nord.xml
@@ -6,9 +6,6 @@
     <filename>@BACKGROUNDDIR@/wave-Light-nord-debian.png</filename>
     <filename-dark>@BACKGROUNDDIR@/wave-Dark-nord-debian.png</filename-dark>
     <options>zoom</options>
-    <shade_type>solid</shade_type>
-    <pcolor>#3071AE</pcolor>
-    <scolor>#000000</scolor>
   </wallpaper>
 </wallpapers>
 

--- a/wallpaper/Graphite-nord/Fedora-Nord.xml
+++ b/wallpaper/Graphite-nord/Fedora-Nord.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>Wave Fedora Nord</name>
+    <filename>@BACKGROUNDDIR@/wave-Light-nord-fedora.png</filename>
+    <filename-dark>@BACKGROUNDDIR@/wave-Dark-nord-fedora.png</filename-dark>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#3071AE</pcolor>
+    <scolor>#000000</scolor>
+  </wallpaper>
+</wallpapers>
+

--- a/wallpaper/Graphite-nord/Fedora-Nord.xml
+++ b/wallpaper/Graphite-nord/Fedora-Nord.xml
@@ -6,9 +6,6 @@
     <filename>@BACKGROUNDDIR@/wave-Light-nord-fedora.png</filename>
     <filename-dark>@BACKGROUNDDIR@/wave-Dark-nord-fedora.png</filename-dark>
     <options>zoom</options>
-    <shade_type>solid</shade_type>
-    <pcolor>#3071AE</pcolor>
-    <scolor>#000000</scolor>
   </wallpaper>
 </wallpapers>
 

--- a/wallpaper/Graphite-nord/Manjaro-Nord.xml
+++ b/wallpaper/Graphite-nord/Manjaro-Nord.xml
@@ -6,9 +6,6 @@
     <filename>@BACKGROUNDDIR@/wave-Light-nord-manjaro.png</filename>
     <filename-dark>@BACKGROUNDDIR@/wave-Dark-nord-manjaro.png</filename-dark>
     <options>zoom</options>
-    <shade_type>solid</shade_type>
-    <pcolor>#3071AE</pcolor>
-    <scolor>#000000</scolor>
   </wallpaper>
 </wallpapers>
 

--- a/wallpaper/Graphite-nord/Manjaro-Nord.xml
+++ b/wallpaper/Graphite-nord/Manjaro-Nord.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>Wave Manjaro Nord</name>
+    <filename>@BACKGROUNDDIR@/wave-Light-nord-manjaro.png</filename>
+    <filename-dark>@BACKGROUNDDIR@/wave-Dark-nord-manjaro.png</filename-dark>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#3071AE</pcolor>
+    <scolor>#000000</scolor>
+  </wallpaper>
+</wallpapers>
+

--- a/wallpaper/Graphite-nord/Pop-Nord.xml
+++ b/wallpaper/Graphite-nord/Pop-Nord.xml
@@ -6,9 +6,6 @@
     <filename>@BACKGROUNDDIR@/wave-Light-nord-pop-os.png</filename>
     <filename-dark>@BACKGROUNDDIR@/wave-Dark-nord-pop-os.png</filename-dark>
     <options>zoom</options>
-    <shade_type>solid</shade_type>
-    <pcolor>#3071AE</pcolor>
-    <scolor>#000000</scolor>
   </wallpaper>
 </wallpapers>
 

--- a/wallpaper/Graphite-nord/Pop-Nord.xml
+++ b/wallpaper/Graphite-nord/Pop-Nord.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>Wave Pop_OS! Nord</name>
+    <filename>@BACKGROUNDDIR@/wave-Light-nord-pop-os.png</filename>
+    <filename-dark>@BACKGROUNDDIR@/wave-Dark-nord-pop-os.png</filename-dark>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#3071AE</pcolor>
+    <scolor>#000000</scolor>
+  </wallpaper>
+</wallpapers>
+

--- a/wallpaper/Graphite-nord/Ubuntu-Nord.xml
+++ b/wallpaper/Graphite-nord/Ubuntu-Nord.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>Wave Ubuntu Nord</name>
+    <filename>@BACKGROUNDDIR@/wave-Light-nord-ubuntu.png</filename>
+    <filename-dark>@BACKGROUNDDIR@/wave-Dark-nord-ubuntu.png</filename-dark>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#3071AE</pcolor>
+    <scolor>#000000</scolor>
+  </wallpaper>
+</wallpapers>
+

--- a/wallpaper/Graphite-nord/Ubuntu-Nord.xml
+++ b/wallpaper/Graphite-nord/Ubuntu-Nord.xml
@@ -6,9 +6,6 @@
     <filename>@BACKGROUNDDIR@/wave-Light-nord-ubuntu.png</filename>
     <filename-dark>@BACKGROUNDDIR@/wave-Dark-nord-ubuntu.png</filename-dark>
     <options>zoom</options>
-    <shade_type>solid</shade_type>
-    <pcolor>#3071AE</pcolor>
-    <scolor>#000000</scolor>
   </wallpaper>
 </wallpapers>
 

--- a/wallpaper/Graphite-nord/Wave-Nord.xml
+++ b/wallpaper/Graphite-nord/Wave-Nord.xml
@@ -6,9 +6,6 @@
     <filename>@BACKGROUNDDIR@/wave-Light-nord.png</filename>
     <filename-dark>@BACKGROUNDDIR@/wave-Dark-nord.png</filename-dark>
     <options>zoom</options>
-    <shade_type>solid</shade_type>
-    <pcolor>#3071AE</pcolor>
-    <scolor>#000000</scolor>
   </wallpaper>
 </wallpapers>
 

--- a/wallpaper/Graphite-nord/Wave-Nord.xml
+++ b/wallpaper/Graphite-nord/Wave-Nord.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>Wave Nord</name>
+    <filename>@BACKGROUNDDIR@/wave-Light-nord.png</filename>
+    <filename-dark>@BACKGROUNDDIR@/wave-Dark-nord.png</filename-dark>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#3071AE</pcolor>
+    <scolor>#000000</scolor>
+  </wallpaper>
+</wallpapers>
+

--- a/wallpaper/Graphite/Arch.xml
+++ b/wallpaper/Graphite/Arch.xml
@@ -6,9 +6,6 @@
     <filename>@BACKGROUNDDIR@/wave-Light-arch.png</filename>
     <filename-dark>@BACKGROUNDDIR@/wave-Dark-arch.png</filename-dark>
     <options>zoom</options>
-    <shade_type>solid</shade_type>
-    <pcolor>#3071AE</pcolor>
-    <scolor>#000000</scolor>
   </wallpaper>
 </wallpapers>
 

--- a/wallpaper/Graphite/Arch.xml
+++ b/wallpaper/Graphite/Arch.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>Wave Arch</name>
+    <filename>@BACKGROUNDDIR@/wave-Light-arch.png</filename>
+    <filename-dark>@BACKGROUNDDIR@/wave-Dark-arch.png</filename-dark>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#3071AE</pcolor>
+    <scolor>#000000</scolor>
+  </wallpaper>
+</wallpapers>
+

--- a/wallpaper/Graphite/Debian.xml
+++ b/wallpaper/Graphite/Debian.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>Wave Debian</name>
+    <filename>@BACKGROUNDDIR@/wave-Light-debian.png</filename>
+    <filename-dark>@BACKGROUNDDIR@/wave-Dark-debian.png</filename-dark>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#3071AE</pcolor>
+    <scolor>#000000</scolor>
+  </wallpaper>
+</wallpapers>
+

--- a/wallpaper/Graphite/Debian.xml
+++ b/wallpaper/Graphite/Debian.xml
@@ -6,9 +6,6 @@
     <filename>@BACKGROUNDDIR@/wave-Light-debian.png</filename>
     <filename-dark>@BACKGROUNDDIR@/wave-Dark-debian.png</filename-dark>
     <options>zoom</options>
-    <shade_type>solid</shade_type>
-    <pcolor>#3071AE</pcolor>
-    <scolor>#000000</scolor>
   </wallpaper>
 </wallpapers>
 

--- a/wallpaper/Graphite/Fedora.xml
+++ b/wallpaper/Graphite/Fedora.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>Wave Fedora</name>
+    <filename>@BACKGROUNDDIR@/wave-Light-fedora.png</filename>
+    <filename-dark>@BACKGROUNDDIR@/wave-Dark-fedora.png</filename-dark>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#3071AE</pcolor>
+    <scolor>#000000</scolor>
+  </wallpaper>
+</wallpapers>
+

--- a/wallpaper/Graphite/Fedora.xml
+++ b/wallpaper/Graphite/Fedora.xml
@@ -6,9 +6,6 @@
     <filename>@BACKGROUNDDIR@/wave-Light-fedora.png</filename>
     <filename-dark>@BACKGROUNDDIR@/wave-Dark-fedora.png</filename-dark>
     <options>zoom</options>
-    <shade_type>solid</shade_type>
-    <pcolor>#3071AE</pcolor>
-    <scolor>#000000</scolor>
   </wallpaper>
 </wallpapers>
 

--- a/wallpaper/Graphite/Manjaro.xml
+++ b/wallpaper/Graphite/Manjaro.xml
@@ -6,9 +6,6 @@
     <filename>@BACKGROUNDDIR@/wave-Light-manjaro.png</filename>
     <filename-dark>@BACKGROUNDDIR@/wave-Dark-manjaro.png</filename-dark>
     <options>zoom</options>
-    <shade_type>solid</shade_type>
-    <pcolor>#3071AE</pcolor>
-    <scolor>#000000</scolor>
   </wallpaper>
 </wallpapers>
 

--- a/wallpaper/Graphite/Manjaro.xml
+++ b/wallpaper/Graphite/Manjaro.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>Wave Manjaro</name>
+    <filename>@BACKGROUNDDIR@/wave-Light-manjaro.png</filename>
+    <filename-dark>@BACKGROUNDDIR@/wave-Dark-manjaro.png</filename-dark>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#3071AE</pcolor>
+    <scolor>#000000</scolor>
+  </wallpaper>
+</wallpapers>
+

--- a/wallpaper/Graphite/Pop.xml
+++ b/wallpaper/Graphite/Pop.xml
@@ -6,9 +6,6 @@
     <filename>@BACKGROUNDDIR@/wave-Light-pop-os.png</filename>
     <filename-dark>@BACKGROUNDDIR@/wave-Dark-pop-os.png</filename-dark>
     <options>zoom</options>
-    <shade_type>solid</shade_type>
-    <pcolor>#3071AE</pcolor>
-    <scolor>#000000</scolor>
   </wallpaper>
 </wallpapers>
 

--- a/wallpaper/Graphite/Pop.xml
+++ b/wallpaper/Graphite/Pop.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>Wave Pop_OS!</name>
+    <filename>@BACKGROUNDDIR@/wave-Light-pop-os.png</filename>
+    <filename-dark>@BACKGROUNDDIR@/wave-Dark-pop-os.png</filename-dark>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#3071AE</pcolor>
+    <scolor>#000000</scolor>
+  </wallpaper>
+</wallpapers>
+

--- a/wallpaper/Graphite/Ubuntu.xml
+++ b/wallpaper/Graphite/Ubuntu.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>Wave Ubuntu</name>
+    <filename>@BACKGROUNDDIR@/wave-Light-ubuntu.png</filename>
+    <filename-dark>@BACKGROUNDDIR@/wave-Dark-ubuntu.png</filename-dark>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#3071AE</pcolor>
+    <scolor>#000000</scolor>
+  </wallpaper>
+</wallpapers>
+

--- a/wallpaper/Graphite/Ubuntu.xml
+++ b/wallpaper/Graphite/Ubuntu.xml
@@ -6,9 +6,6 @@
     <filename>@BACKGROUNDDIR@/wave-Light-ubuntu.png</filename>
     <filename-dark>@BACKGROUNDDIR@/wave-Dark-ubuntu.png</filename-dark>
     <options>zoom</options>
-    <shade_type>solid</shade_type>
-    <pcolor>#3071AE</pcolor>
-    <scolor>#000000</scolor>
   </wallpaper>
 </wallpapers>
 

--- a/wallpaper/Graphite/Wave.xml
+++ b/wallpaper/Graphite/Wave.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>Wave</name>
+    <filename>@BACKGROUNDDIR@/wave-Light.png</filename>
+    <filename-dark>@BACKGROUNDDIR@/wave-Dark.png</filename-dark>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#3071AE</pcolor>
+    <scolor>#000000</scolor>
+  </wallpaper>
+</wallpapers>
+

--- a/wallpaper/Graphite/Wave.xml
+++ b/wallpaper/Graphite/Wave.xml
@@ -6,9 +6,6 @@
     <filename>@BACKGROUNDDIR@/wave-Light.png</filename>
     <filename-dark>@BACKGROUNDDIR@/wave-Dark.png</filename-dark>
     <options>zoom</options>
-    <shade_type>solid</shade_type>
-    <pcolor>#3071AE</pcolor>
-    <scolor>#000000</scolor>
   </wallpaper>
 </wallpapers>
 

--- a/wallpaper/install-wallpapers.sh
+++ b/wallpaper/install-wallpapers.sh
@@ -2,6 +2,7 @@
 
 REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
 WALLPAPER_DIR="$HOME/.local/share/backgrounds"
+XML_DIR="$HOME/.local/share/gnome-background-properties"
 
 THEME_NAME='Graphite'
 THEME_VARIANTS=('' '-nord')
@@ -35,6 +36,10 @@ prompt () {
   esac
 }
 
+old_string="@BACKGROUNDDIR@"
+
+new_filepath="$HOME/.local/share/backgrounds/"
+
 install() {
   local theme="$1"
 
@@ -42,6 +47,10 @@ install() {
   mkdir -p "${WALLPAPER_DIR}"
 
   cp -rf ${REPO_DIR}/${THEME_NAME}${theme}/*.png ${WALLPAPER_DIR}
+  cp -rf ${REPO_DIR}/${THEME_NAME}${theme}/*.xml ${XML_DIR}
+  for file in "$XML_DIR"/*; do
+    sed -i "s/$old_string/$(printf '%s\n' "$new_filepath" | sed 's/[\/&]/\\&/g')/g" "$file"
+  done
 }
 
 if [[ "${#themes[@]}" -eq 0 ]] ; then

--- a/wallpaper/install-wallpapers.sh
+++ b/wallpaper/install-wallpapers.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
 REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
-WALLPAPER_DIR="$HOME/.local/share/backgrounds"
+WALLPAPER_DIR="$HOME/.local/share/Graphite-backgrounds"
 XML_DIR="$HOME/.local/share/gnome-background-properties"
+old_string="@BACKGROUNDDIR@"
+
 
 THEME_NAME='Graphite'
 THEME_VARIANTS=('' '-nord')
@@ -36,20 +38,18 @@ prompt () {
   esac
 }
 
-old_string="@BACKGROUNDDIR@"
-
-new_filepath="$HOME/.local/share/backgrounds/"
-
 install() {
   local theme="$1"
 
   prompt -i "\n * Install ${THEME_NAME}${theme} in ${WALLPAPER_DIR}... "
   mkdir -p "${WALLPAPER_DIR}"
+  mkdir -p "${XML_DIR}"
+  mkdir -p "${new_filepath}"
 
   cp -rf ${REPO_DIR}/${THEME_NAME}${theme}/*.png ${WALLPAPER_DIR}
   cp -rf ${REPO_DIR}/${THEME_NAME}${theme}/*.xml ${XML_DIR}
   for file in "$XML_DIR"/*; do
-    sed -i "s/$old_string/$(printf '%s\n' "$new_filepath" | sed 's/[\/&]/\\&/g')/g" "$file"
+    sed -i "s/$old_string/$(printf '%s\n' "$WALLPAPER_DIR" | sed 's/[\/&]/\\&/g')/g" "$file"
   done
 }
 


### PR DESCRIPTION
This PR simply adds XML for the wallpapers to make them work with the Gnome 42+ Light/Dark wallpaper functionality
at the same time it moves where the `install_wallpapers.sh` script places the wallpapers to a graphite specific location to make it not show up twice in the appearance settings.
I'm gonna try and make it account for if Gnome is older than Gnome 42 at a later time if it is necessary. 
![image](https://github.com/vinceliuice/Graphite-gtk-theme/assets/75324436/35423069-5c96-45f2-88ee-1751be0a27f2)
