### PR TITLE
Some fixes. Slider, notifications, calculator app

### DIFF
--- a/src/sass/gnome-shell/common/_notifications.scss
+++ b/src/sass/gnome-shell/common/_notifications.scss
@@ -8,7 +8,9 @@
   border-radius: $base_radius;
   color: $text-secondary;
   background-color: $popover;
-  border: none;
+  border-style: solid;
+  border-color: $text-secondary;
+  border-width: 2px;
   text-shadow: none;
   box-shadow: 0 3px 5px rgba(0, 0, 0, 0.25);
   border-radius: $menu_radius;
@@ -16,8 +18,8 @@
   &:hover {
     color: $text;
     background-color: $popover;
-    box-shadow: 0 5px 12px rgba(0, 0, 0, 0.25);
-    margin: 12px 12px 18px;
+    box-shadow: 0 3px 5px rgba(0, 0, 0, 0.25);
+    margin: 12px 8px 8px;
   }
 
   &:focus {

--- a/src/sass/gnome-shell/common/_panel.scss
+++ b/src/sass/gnome-shell/common/_panel.scss
@@ -259,8 +259,8 @@
   Gjs_status_keyboard_InputSourceIndicator.panel-button, // Ibus
   Gjs_appindicatorsupport_rgcjonas_gmail_com_indicatorStatusIcon_IndicatorStatusIcon.panel-button,
   Gjs_appindicatorsupport_rgcjonas_gmail_com_indicatorStatusIcon_AppIndicatorsIndicatorStatusIcon.panel-button { // Fcitx
-    -natural-hpadding: $base_padding * 3 !important;
-    -minimum-hpadding: $base_padding * 3 !important;
+    -natural-hpadding: 12px !important;
+    -minimum-hpadding: 12px !important;
   }
 
   @mixin colorful_button($theme_color: $primary) {

--- a/src/sass/gnome-shell/common/_slider.scss
+++ b/src/sass/gnome-shell/common/_slider.scss
@@ -5,7 +5,7 @@ $slide_size: if($compact == 'false', 8px, 7px);
 
 .slider {
   height: 20px;
-  color: $base;
+  color: $slide_active_color;
 
   -slider-height: 2px;
   -slider-background-color: $track; //background of the trough

--- a/src/sass/gnome-shell/widgets-46-0/_notifications.scss
+++ b/src/sass/gnome-shell/widgets-46-0/_notifications.scss
@@ -8,10 +8,11 @@ $notification_banner_width: 34em;
   min-height: $notification_banner_height;
   width: $notification_banner_width;
   margin: 12px 8px 8px;
-  border-radius: $base_radius;
   color: $text-secondary;
   background-color: $popover;
-  border: none;
+  border-style: solid;
+  border-color: $text-secondary;
+  border-width: 2px;
   text-shadow: none;
   box-shadow: 0 3px 5px rgba(0, 0, 0, 0.25);
   border-radius: $menu_radius;
@@ -19,8 +20,8 @@ $notification_banner_width: 34em;
   &:hover {
     color: $text;
     background-color: $popover;
-    box-shadow: 0 5px 12px rgba(0, 0, 0, 0.25);
-    margin: 12px 12px 18px;
+    box-shadow: 0 3px 5px rgba(0, 0, 0, 0.25);
+    margin: 12px 8px 8px;
   }
 
   &:focus {

--- a/src/sass/gtk/_common-3.0.scss
+++ b/src/sass/gtk/_common-3.0.scss
@@ -528,7 +528,7 @@ button {
     padding-right: 16px;
 
     &.flat {
-      min-width: 64px - 8px * 2;
+      min-width: 16px;
       padding-left: 8px;
       padding-right: 8px;
     }

--- a/src/sass/gtk/_common-4.0.scss
+++ b/src/sass/gtk/_common-4.0.scss
@@ -497,7 +497,7 @@ button {
     padding-right: 16px;
 
     &.flat {
-      min-width: 64px - 8px * 2;
+      min-width: 16px;
       padding-left: 8px;
       padding-right: 8px;
     }


### PR DESCRIPTION
* Added border and fixed notification window size change on hover
* Fixed black color of the quick settings sliders handle on gnome 47
* Decrease appindicator icons width
* Decrease width of the flat button. Fixes large width of the Calculator app