### PR TITLE
fix: fedora grub installer

### DIFF
--- a/other/grub2/install.sh
+++ b/other/grub2/install.sh
@@ -211,16 +211,14 @@ updating_grub() {
   elif has_command zypper; then
     grub2-mkconfig -o /boot/grub2/grub.cfg
   elif has_command dnf; then
-    if [[ -f /boot/efi/EFI/fedora/grub.cfg ]]; then
-      prompt -i "Find config file on /boot/efi/EFI/fedora/grub.cfg ...\n"
-      grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg
-    fi
     if [[ -f /boot/grub2/grub.cfg ]]; then
       prompt -i "Find config file on /boot/grub2/grub.cfg ...\n"
       grub2-mkconfig -o /boot/grub2/grub.cfg
+    elif [[ -f /boot/efi/EFI/fedora/grub.cfg ]]; then
+      prompt -i "Find config file on /boot/efi/EFI/fedora/grub.cfg ...\n"
+      grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg
     fi
   fi
-
   # Success message
   prompt -s "\n * All done!"
 }


### PR DESCRIPTION
# Output before:
 Checking for the existence of themes directory... 
  
 Installing Graphite 2k theme... 
  
 Setting Graphite as default... 
  
 Updating grub config...
 
  Find config file on /boot/efi/EFI/fedora/grub.cfg ...
 
Running `grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg' will overwrite the GRUB wrapper.
Please run `grub2-mkconfig -o /boot/grub2/grub.cfg' instead to update grub.cfg.
GRUB configuration file was not updated.


# Output now:
 Checking for the existence of themes directory... 
  
 Installing Graphite 2k theme... 
  
 Setting Graphite as default... 
  
 Updating grub config...
 
  Find config file on /boot/grub2/grub.cfg ...
 
Generating grub configuration file ...
Found theme: /usr/share/grub/themes/Graphite/theme.txt
Found linux image: /boot/vmlinuz-6...
Found initrd image: /boot/initramfs-6...
Found linux image: /boot/vmlinuz-6...
Found initrd image: /boot/initramfs-6...
Found linux image: /boot/vmlinuz-0-rescue-...
Found initrd image: /boot/initramfs-0-rescue-...
Adding boot menu entry for UEFI Firmware Settings ...
done
  
 * All done! 
  
 * At the next restart of your computer you will see your new Grub theme: 'Graphite'  